### PR TITLE
Fix: Ensure two-way binding for Weight_T and its visibility in Jobs.xaml

### DIFF
--- a/WCA/WCA/Models/CustomerContainer.cs
+++ b/WCA/WCA/Models/CustomerContainer.cs
@@ -27,7 +27,20 @@ namespace WCA.Models
                 }
             }
         }
-        public bool WeightVisibility { get; set; }
+
+        private bool _weightVisibility;
+        public bool WeightVisibility
+        {
+            get { return _weightVisibility; }
+            set
+            {
+                if (_weightVisibility != value)
+                {
+                    _weightVisibility = value;
+                    OnPropertyChanged(nameof(WeightVisibility));
+                }
+            }
+        }
         public string CPID { get; set; }
         public int RunNo { get; set; }
         public bool Completed { get; set; }
@@ -94,7 +107,7 @@ namespace WCA.Models
             IsVisibilityWasteType = isvisibilitywastetype;
             SiteName = sitename;
             CPID = cpid;
-            WeightVisibility = false;
+            this.WeightVisibility = false;
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/WCA/WCA/ViewModels/CustomerContainerViewModel.cs
+++ b/WCA/WCA/ViewModels/CustomerContainerViewModel.cs
@@ -21,7 +21,24 @@ namespace WCA.ViewModels
         public CustomerContainerViewModel(CustomerContainer customer_container)
         {
             this._customer_container = customer_container;
+            this._customer_container.PropertyChanged += CustomerContainer_PropertyChanged;
         }
+
+        private void CustomerContainer_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(CustomerContainer.WeightVisibility))
+            {
+                OnPropertyChanged(nameof(WeightVisibility));
+            }
+            // Optional: If Weight_T could also be changed directly in the model
+            // by some other process AND the ViewModel needs to be notified,
+            // add a similar check for Weight_T.
+            // if (e.PropertyName == nameof(CustomerContainer.Weight_T))
+            // {
+            //     OnPropertyChanged(nameof(Weight_T));
+            // }
+        }
+
         public string ContainerName { get { return _customer_container.ContainerName; } }
         public int Qty { get { return _customer_container.Qty; } }
         public int ExtraWasteId { get { return _customer_container.ExtraWasteId; } }
@@ -36,6 +53,32 @@ namespace WCA.ViewModels
         }*/
         public int RunNo { get { return _customer_container.RunNo; } }
         public string CustomerID { get { return _customer_container.CustomerID; } }
+
+        public int Weight_T
+        {
+            get { return _customer_container.Weight_T; }
+            set
+            {
+                if (_customer_container.Weight_T != value)
+                {
+                    _customer_container.Weight_T = value;
+                    OnPropertyChanged(nameof(Weight_T)); // Ensure BaseViewModel or this class has OnPropertyChanged
+                }
+            }
+        }
+
+        public bool WeightVisibility
+        {
+            get { return _customer_container.WeightVisibility; }
+            set
+            {
+                if (_customer_container.WeightVisibility != value)
+                {
+                    _customer_container.WeightVisibility = value;
+                    OnPropertyChanged(nameof(WeightVisibility)); // Ensure BaseViewModel or this class has OnPropertyChanged
+                }
+            }
+        }
 
         public bool ChargeAsContract
         {


### PR DESCRIPTION
The Weight_T and WeightVisibility properties were not correctly displayed or updated in the job list items.

This was resolved by:
1. Adding `Weight_T` and `WeightVisibility` properties to `CustomerContainerViewModel.cs`, which proxy the corresponding properties from the `CustomerContainer` model. These ViewModel properties include `OnPropertyChanged` notifications.
2. Modifying `CustomerContainer.cs` to ensure its `WeightVisibility` property correctly implements `INotifyPropertyChanged` (it already did for `Weight_T`).
3. Enhancing `CustomerContainerViewModel.cs` to subscribe to the `PropertyChanged` event of its `CustomerContainer` model. This ensures that if `WeightVisibility` is changed directly on the model (e.g., by `JobsViewModel`), the `CustomerContainerViewModel` is notified and updates the UI accordingly.

The XAML bindings in `Jobs.xaml` for `Weight_T` and `WeightVisibility` were already correctly defined to use these property names and will now function as expected.