### PR TITLE
Fix: Align 'Weight' header label visibility with item weight visibility

### DIFF
--- a/WCA/WCA/ViewModels/JobsViewModel.cs
+++ b/WCA/WCA/ViewModels/JobsViewModel.cs
@@ -637,6 +637,8 @@ namespace WCA.ViewModels
                     _expanded = value;
                     OnPropertyChanged(new PropertyChangedEventArgs("Expanded"));
                     OnPropertyChanged(new PropertyChangedEventArgs("StateIcon"));
+                    OnPropertyChanged(nameof(HeaderWeightLabelVisibility)); // Added this line
+
                     if (_expanded)
                     {
                         this.AddRange(jobCustomerContainers);
@@ -668,6 +670,11 @@ namespace WCA.ViewModels
 
                 }
             }
+        }
+
+        public bool HeaderWeightLabelVisibility
+        {
+            get { return Expanded && (Globals.Vehicle_Type == 1 || Globals.Vehicle_Type == 11); }
         }
 
         public void weightUpdateWasteType(bool visibility) {

--- a/WCA/WCA/Views/Jobs.xaml
+++ b/WCA/WCA/Views/Jobs.xaml
@@ -207,7 +207,7 @@
                                         <Label Grid.Column="2" Grid.Row="0" 
                                          VerticalOptions="Center"
                                          Text="Weight"  FontAttributes="Bold"  
-                                         IsVisible="{Binding Expanded}"/>
+                                         IsVisible="{Binding HeaderWeightLabelVisibility}"/>
                                         <Label Grid.Column="3" Grid.Row="0" 
                                            VerticalOptions="Center"
                                            Text="Extra Waste"  FontAttributes="Bold"  


### PR DESCRIPTION
The 'Weight' header label in the job grouping was previously only tied to the 'Expanded' state of the group. This change updates its visibility to also depend on the same `Globals.Vehicle_Type` conditions that control the visibility of the weight input fields for individual job items.

1. Added a `HeaderWeightLabelVisibility` boolean property to `JobsViewModel.cs`.
   - Its getter returns `Expanded && (Globals.Vehicle_Type == 1 || Globals.Vehicle_Type == 11)`.
   - The `Expanded` property setter in `JobsViewModel` now also triggers `OnPropertyChanged` for `HeaderWeightLabelVisibility`.
2. Modified `Jobs.xaml`:
   - The `IsVisible` property of the 'Weight' header `Label` in the `ListView.GroupHeaderTemplate` is now bound to `HeaderWeightLabelVisibility` instead of just `Expanded`.